### PR TITLE
remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "Highcharts wrapper for browserify",
   "main": "index.js",
   "browser": "browser.js",
+  "files": [
+    "browser.js",
+    "index.js"
+  ],
   "scripts": {
     "prepublish": "npm run build",
     "build": "node build.js",
-    "test": "npm run build && tape test/*.js",
-    "postinstall": "npm run build"
+    "test": "npm run build && tape test/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Instead, let's rely on the prepublish script to build and include `index.js` in the published package. This would allow one to use highcharts-browserify in, for example, requirebin.com, because wzrd.in (which browserifies the modules) does not run `postinstall` scripts.

I have also removed the `.npmignore` file, because it was spelled wrong :) and gets in the way of the `"files"` attribute.

The `"files"` attribute in the `package.json` will allow us to only include the necessary files:

``` sh
$ npm pack
$ tar -tf highcharts-browserify-0.1.3-4.0.4.tgz
package/package.json
package/README.md
package/LICENSE
package/browser.js
package/index.js
```