### PR TITLE
Badly broken exotic semver fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highcharts-browserify",
-  "version": "0.1.4-4.0.4",
+  "version": "0.1.5",
   "description": "Highcharts wrapper for browserify",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
This is a version zero release, which is already by definition prerelease.

Unfortunately an exotic semver has also been chosen to further show pre-release status. This breaks NPM.

https://github.com/soldair/highcharts-browserify/issues/6#issuecomment-122122952