### PR TITLE
use valid SPDX license

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "graph"
   ],
   "author": "Ryan Day <soldair@gmail.com>",
-  "license": "MIT / http://www.highcharts.com/license/",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/soldair/highcharts-browserify/issues"
   },


### PR DESCRIPTION
Fixes `npm` warning:

```
npm WARN EPACKAGEJSON highcharts-browserify@0.1.5 license should be a valid SPDX license expression
```